### PR TITLE
Fix: Image component with border wasn't aligned correctly.

### DIFF
--- a/haxe/ui/backend/ComponentBase.hx
+++ b/haxe/ui/backend/ComponentBase.hx
@@ -1,5 +1,6 @@
 package haxe.ui.backend;
 
+import haxe.ui.components.Image;
 import haxe.ui.core.KeyboardEvent;
 import haxe.ui.components.TextField;
 import haxe.ui.backend.html5.EventMapper;
@@ -144,6 +145,10 @@ class ComponentBase {
             newElement.style.setProperty("-ms-user-select", "none");
             newElement.style.setProperty("user-select", "none");
             newElement.style.position = "absolute";
+
+            if (Std.is(this, Image)) {
+                newElement.style.boxSizing = "initial";
+            }
 
             if (element != null) {
                 var p = element.parentElement;


### PR DESCRIPTION
Using the next code:

```
<image id="image" resource="img/image.jpg"
               width="200" height="200"
               style="border: 1px solid #000000; padding: 2px;"/>
```

has the result: 

![bughtml5](https://cloud.githubusercontent.com/assets/1063719/21529964/912bb8ce-cd3d-11e6-8ce6-45404e36981d.JPG)

It should have 2px padding-left but it has 2px padding-left + 1px border-width.

By default, box-sizing is `content-box`, and it uses the border width to get in account the full size. Currently it works with another components with `margin` offset but it doesn't work with the Image component. With the "box-sizing=initial" value, it works. 

![image](https://cloud.githubusercontent.com/assets/1063719/21530064/571baca6-cd3e-11e6-8933-0e5635cd5a7b.png)
