### PR TITLE
Use HTML5 Pointer Events API instead of deprecated MouseEvent and TouchEvent

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -607,25 +607,39 @@ class ComponentImpl extends ComponentBase {
     private function __onMouseEvent(event:js.html.Event) {
         // TODO: conditionally implement: https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture
         // especially for scrolls
+        var pe:js.html.PointerEvent = cast(event, js.html.PointerEvent);
+
         var type:String = EventMapper.DOM_TO_HAXEUI.get(event.type);
         if (type != null) {
+            // if (event.type == "pointerdown") { // handle right button mouse events better
+            //     var which:Int = Reflect.field(event, "which");
+            //     switch (which) {
+            //         case 1: type = MouseEvent.MOUSE_DOWN;
+            //         case 2: type = MouseEvent.MOUSE_DOWN; // should be mouse middle, but there is no haxe equiv (yet);
+            //         case 3: type = MouseEvent.RIGHT_MOUSE_DOWN;
+            //     }
+            // } else if (event.type == "pointerup") { // handle right button mouse events better
+            //     var which:Int = Reflect.field(event, "which");
+            //     switch (which) {
+            //         case 1: type = MouseEvent.MOUSE_UP;
+            //         case 2: type = MouseEvent.MOUSE_UP; // should be mouse middle, but there is no haxe equiv (yet);
+            //         case 3: type = MouseEvent.RIGHT_MOUSE_UP;
+            //     }
+            // }
+
             if (event.type == "pointerdown") { // handle right button mouse events better
-                var which:Int = Reflect.field(event, "which");
-                switch (which) {
-                    case 1: type = MouseEvent.MOUSE_DOWN;
-                    case 2: type = MouseEvent.MOUSE_DOWN; // should be mouse middle, but there is no haxe equiv (yet);
-                    case 3: type = MouseEvent.RIGHT_MOUSE_DOWN;
+                switch (pe.button) {
+                    case 0: type = MouseEvent.MOUSE_DOWN;
+                    case 2: type = MouseEvent.RIGHT_MOUSE_DOWN;
                 }
             } else if (event.type == "pointerup") { // handle right button mouse events better
-                var which:Int = Reflect.field(event, "which");
-                switch (which) {
-                    case 1: type = MouseEvent.MOUSE_UP;
-                    case 2: type = MouseEvent.MOUSE_UP; // should be mouse middle, but there is no haxe equiv (yet);
-                    case 3: type = MouseEvent.RIGHT_MOUSE_UP;
+                switch (pe.button) {
+                    case 0: type = MouseEvent.MOUSE_UP;
+                    case 2: type = MouseEvent.RIGHT_MOUSE_UP;
                 }
             }
+
             try { // use setPointerCapture instead of setCapture, the latter is deprecated
-                var pe:js.html.PointerEvent = cast(event, js.html.PointerEvent);
                 if (type == MouseEvent.MOUSE_DOWN) {
                     element.setPointerCapture(pe.pointerId);
                 } else if (type == MouseEvent.MOUSE_UP) {

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -434,8 +434,8 @@ class ScreenImpl extends ScreenBase {
         //     touchEvent = (event is js.html.TouchEvent);
         // } catch (e:Dynamic) { }
         // if (touchEvent == false && (event is js.html.MouseEvent)) {
-            var me:js.html.PointerEvent = cast(event, js.html.PointerEvent);
-            button = me.which;
+            var pe:js.html.PointerEvent = cast(event, js.html.PointerEvent);
+            button = pe.which;
         // }
         
         var r = true;
@@ -446,18 +446,14 @@ class ScreenImpl extends ScreenBase {
             r = false;
         }
         if (event.type == "pointerdown") { // handle right button mouse events better
-            var which:Int = Reflect.field(event, "which");
-            switch (which) {
-                case 1: type = MouseEvent.MOUSE_DOWN;
-                case 2: type = MouseEvent.MOUSE_DOWN; // should be mouse middle, but there is no haxe equiv (yet);
-                case 3: type = MouseEvent.RIGHT_MOUSE_DOWN;
+            switch (pe.button) {
+                case 0: type = MouseEvent.MOUSE_DOWN;
+                case 2: type = MouseEvent.RIGHT_MOUSE_DOWN;
             }
         } else if (event.type == "pointerup") { // handle right button mouse events better
-            var which:Int = Reflect.field(event, "which");
-            switch (which) {
-                case 1: type = MouseEvent.MOUSE_UP;
-                case 2: type = MouseEvent.MOUSE_UP; // should be mouse middle, but there is no haxe equiv (yet);
-                case 3: type = MouseEvent.RIGHT_MOUSE_UP;
+            switch (pe.button) {
+                case 0: type = MouseEvent.MOUSE_UP;
+                case 2: type = MouseEvent.RIGHT_MOUSE_UP;
             }
         }
 

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -429,14 +429,14 @@ class ScreenImpl extends ScreenBase {
         //event.preventDefault();
 
         var button:Int = -1;
-        var touchEvent = false;
-        try {
-            touchEvent = (event is js.html.TouchEvent);
-        } catch (e:Dynamic) { }
-        if (touchEvent == false && (event is js.html.MouseEvent)) {
-            var me:js.html.MouseEvent = cast(event, js.html.MouseEvent);
+        // var touchEvent = false;
+        // try {
+        //     touchEvent = (event is js.html.TouchEvent);
+        // } catch (e:Dynamic) { }
+        // if (touchEvent == false && (event is js.html.MouseEvent)) {
+            var me:js.html.PointerEvent = cast(event, js.html.PointerEvent);
             button = me.which;
-        }
+        // }
         
         var r = true;
         var type:String = EventMapper.DOM_TO_HAXEUI.get(event.type);
@@ -445,14 +445,14 @@ class ScreenImpl extends ScreenBase {
             event.preventDefault();
             r = false;
         }
-        if (event.type == "mousedown") { // handle right button mouse events better
+        if (event.type == "pointerdown") { // handle right button mouse events better
             var which:Int = Reflect.field(event, "which");
             switch (which) {
                 case 1: type = MouseEvent.MOUSE_DOWN;
                 case 2: type = MouseEvent.MOUSE_DOWN; // should be mouse middle, but there is no haxe equiv (yet);
                 case 3: type = MouseEvent.RIGHT_MOUSE_DOWN;
             }
-        } else if (event.type == "mouseup") { // handle right button mouse events better
+        } else if (event.type == "pointerup") { // handle right button mouse events better
             var which:Int = Reflect.field(event, "which");
             switch (which) {
                 case 1: type = MouseEvent.MOUSE_UP;
@@ -468,18 +468,19 @@ class ScreenImpl extends ScreenBase {
                 var mouseEvent = new MouseEvent(type);
                 mouseEvent._originalEvent = event;
 
-                if (touchEvent == true) {
-                    var te:js.html.TouchEvent = cast(event, js.html.TouchEvent);
-                    mouseEvent.screenX = (te.changedTouches[0].pageX - Screen.instance.container.offsetLeft) / Toolkit.scaleX;
-                    mouseEvent.screenY = (te.changedTouches[0].pageY - Screen.instance.container.offsetTop) / Toolkit.scaleY;
-                    mouseEvent.touchEvent = true;
-                } else if ((event is js.html.MouseEvent)) {
-                    var me:js.html.MouseEvent = cast(event, js.html.MouseEvent);
-                    mouseEvent.buttonDown = (me.buttons != 0);
-                    mouseEvent.screenX = (me.pageX - Screen.instance.container.offsetLeft) / Toolkit.scaleX;
-                    mouseEvent.screenY = (me.pageY - Screen.instance.container.offsetTop) / Toolkit.scaleY;
-                    mouseEvent.ctrlKey = me.ctrlKey;
-                    mouseEvent.shiftKey = me.shiftKey;
+                // if (touchEvent == true) {
+                //     var te:js.html.TouchEvent = cast(event, js.html.TouchEvent);
+                //     mouseEvent.screenX = (te.changedTouches[0].pageX - Screen.instance.container.offsetLeft) / Toolkit.scaleX;
+                //     mouseEvent.screenY = (te.changedTouches[0].pageY - Screen.instance.container.offsetTop) / Toolkit.scaleY;
+                //     mouseEvent.touchEvent = true;
+                // } else if ((event is js.html.MouseEvent)) {
+                if ((event is js.html.PointerEvent)) {
+                    var pe:js.html.PointerEvent = cast(event, js.html.PointerEvent);
+                    mouseEvent.buttonDown = (pe.buttons != 0);
+                    mouseEvent.screenX = (pe.pageX - Screen.instance.container.offsetLeft) / Toolkit.scaleX;
+                    mouseEvent.screenY = (pe.pageY - Screen.instance.container.offsetTop) / Toolkit.scaleY;
+                    mouseEvent.ctrlKey = pe.ctrlKey;
+                    mouseEvent.shiftKey = pe.shiftKey;
                 }
 
                 fn(mouseEvent);

--- a/haxe/ui/backend/html5/EventMapper.hx
+++ b/haxe/ui/backend/html5/EventMapper.hx
@@ -3,7 +3,7 @@ package haxe.ui.backend.html5;
 class EventMapper {
     public static var HAXEUI_TO_DOM:Map<String, String> = [
         haxe.ui.events.MouseEvent.MOUSE_MOVE => "pointermove",
-        haxe.ui.events.MouseEvent.MOUSE_OVER => "pointerenter",
+        haxe.ui.events.MouseEvent.MOUSE_OVER => "pointerover",
         haxe.ui.events.MouseEvent.MOUSE_OUT => "pointerout",
         haxe.ui.events.MouseEvent.MOUSE_DOWN => "pointerdown",
         haxe.ui.events.MouseEvent.MOUSE_UP => "pointerup",
@@ -20,7 +20,7 @@ class EventMapper {
 
     public static var DOM_TO_HAXEUI:Map<String, String> = [
         "pointermove" => haxe.ui.events.MouseEvent.MOUSE_MOVE,
-        "pointerenter" => haxe.ui.events.MouseEvent.MOUSE_OVER,
+        "pointerover" => haxe.ui.events.MouseEvent.MOUSE_OVER,
         "pointerout" => haxe.ui.events.MouseEvent.MOUSE_OUT,
         "pointerdown" => haxe.ui.events.MouseEvent.MOUSE_DOWN,
         "pointerup" => haxe.ui.events.MouseEvent.MOUSE_UP,

--- a/haxe/ui/backend/html5/EventMapper.hx
+++ b/haxe/ui/backend/html5/EventMapper.hx
@@ -2,11 +2,11 @@ package haxe.ui.backend.html5;
 
 class EventMapper {
     public static var HAXEUI_TO_DOM:Map<String, String> = [
-        haxe.ui.events.MouseEvent.MOUSE_MOVE => "mousemove",
-        haxe.ui.events.MouseEvent.MOUSE_OVER => "mouseover",
-        haxe.ui.events.MouseEvent.MOUSE_OUT => "mouseout",
-        haxe.ui.events.MouseEvent.MOUSE_DOWN => "mousedown",
-        haxe.ui.events.MouseEvent.MOUSE_UP => "mouseup",
+        haxe.ui.events.MouseEvent.MOUSE_MOVE => "pointermove",
+        haxe.ui.events.MouseEvent.MOUSE_OVER => "pointerenter",
+        haxe.ui.events.MouseEvent.MOUSE_OUT => "pointerout",
+        haxe.ui.events.MouseEvent.MOUSE_DOWN => "pointerdown",
+        haxe.ui.events.MouseEvent.MOUSE_UP => "pointerup",
         haxe.ui.events.MouseEvent.CLICK => "click",
         haxe.ui.events.MouseEvent.DBL_CLICK => "dblclick",
         haxe.ui.events.MouseEvent.RIGHT_MOUSE_DOWN => "mousedown",
@@ -19,14 +19,11 @@ class EventMapper {
     ];
 
     public static var DOM_TO_HAXEUI:Map<String, String> = [
-        "mousemove" => haxe.ui.events.MouseEvent.MOUSE_MOVE,
-        "mouseover" => haxe.ui.events.MouseEvent.MOUSE_OVER,
-        "mouseout" => haxe.ui.events.MouseEvent.MOUSE_OUT,
-        "mousedown" => haxe.ui.events.MouseEvent.MOUSE_DOWN,
-        "mouseup" => haxe.ui.events.MouseEvent.MOUSE_UP,
-        "touchmove" => haxe.ui.events.MouseEvent.MOUSE_MOVE,
-        "touchstart" => haxe.ui.events.MouseEvent.MOUSE_DOWN,
-        "touchend" => haxe.ui.events.MouseEvent.MOUSE_UP,
+        "pointermove" => haxe.ui.events.MouseEvent.MOUSE_MOVE,
+        "pointerenter" => haxe.ui.events.MouseEvent.MOUSE_OVER,
+        "pointerout" => haxe.ui.events.MouseEvent.MOUSE_OUT,
+        "pointerdown" => haxe.ui.events.MouseEvent.MOUSE_DOWN,
+        "pointerup" => haxe.ui.events.MouseEvent.MOUSE_UP,
         "click" => haxe.ui.events.MouseEvent.CLICK,
         "contextmenu" => haxe.ui.events.MouseEvent.RIGHT_CLICK,
         "dblclick" => haxe.ui.events.MouseEvent.DBL_CLICK,
@@ -37,14 +34,14 @@ class EventMapper {
     ];
     
     public static var MOUSE_TO_TOUCH:Map<String, String> = [
-        haxe.ui.events.MouseEvent.MOUSE_MOVE => "touchmove",
-        haxe.ui.events.MouseEvent.MOUSE_DOWN => "touchstart",
-        haxe.ui.events.MouseEvent.MOUSE_UP => "touchend"
+        haxe.ui.events.MouseEvent.MOUSE_MOVE => "pointermove",
+        haxe.ui.events.MouseEvent.MOUSE_DOWN => "pointerdown",
+        haxe.ui.events.MouseEvent.MOUSE_UP => "pointerup"
     ];
     
     public static var TOUCH_TO_MOUSE:Map<String, String> = [
-        "touchmove" => haxe.ui.events.MouseEvent.MOUSE_MOVE,
-        "touchstart" => haxe.ui.events.MouseEvent.MOUSE_OUT,
-        "touchend" => haxe.ui.events.MouseEvent.MOUSE_DOWN
+        "pointermove" => haxe.ui.events.MouseEvent.MOUSE_MOVE,
+        "pointerout" => haxe.ui.events.MouseEvent.MOUSE_OUT,
+        "pointerdown" => haxe.ui.events.MouseEvent.MOUSE_DOWN
     ];
 }


### PR DESCRIPTION
This PR makes some changes to respond to the more modern and input-agnostic Pointer Events API for input from the browser, rather than relying on the older MouseEvent and TouchEvent APIs. This helps it to work better with input devices like pen/stylus, without adversely changing the existing mouse-oriented code.


https://user-images.githubusercontent.com/79861976/205028414-6c809924-9dab-4904-9895-28340acc1fb9.mp4

