### PR TITLE
Being able to cancel backdrop filters

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -341,13 +341,12 @@ class ComponentImpl extends ComponentBase {
 
         FilterHelper.applyFilters(this.element, style.filter);
 
+        element.style.removeProperty("backdrop-filter");
         if (style.backdropFilter != null) {
             if ((style.backdropFilter[0] is Blur)) {
                 var blur:Blur = cast style.backdropFilter[0];
                 element.style.setProperty("backdrop-filter", 'blur(${blur.amount}px)');
             }
-        } else {
-            element.style.removeProperty("backdrop-filter");
         }
         
         if (style.opacity != null) {


### PR DESCRIPTION
`backdrop-filter: none;` returns a empty list.
An empty list or some non blur filters should be able to remove the previous filter