### PR TITLE
update mouse events now that we have middle mouse equivalent in haxe

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -496,7 +496,8 @@ class ComponentImpl extends ComponentBase {
         switch (type) {
             case MouseEvent.MOUSE_MOVE | MouseEvent.MOUSE_OVER | MouseEvent.MOUSE_OUT |
                 MouseEvent.MOUSE_DOWN | MouseEvent.MOUSE_UP | MouseEvent.CLICK | MouseEvent.DBL_CLICK |
-                MouseEvent.RIGHT_MOUSE_DOWN | MouseEvent.RIGHT_MOUSE_UP:
+                MouseEvent.RIGHT_MOUSE_DOWN | MouseEvent.RIGHT_MOUSE_UP | MouseEvent.MIDDLE_MOUSE_DOWN |
+                MouseEvent.MIDDLE_MOUSE_UP:
                 _eventMap.remove(type);
                 element.removeEventListener(EventMapper.HAXEUI_TO_DOM.get(type), __onMouseEvent);
                 if (type == MouseEvent.RIGHT_MOUSE_DOWN || type == MouseEvent.RIGHT_MOUSE_UP) {

--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -442,7 +442,8 @@ class ComponentImpl extends ComponentBase {
         switch (type) {
             case MouseEvent.MOUSE_MOVE | MouseEvent.MOUSE_OVER | MouseEvent.MOUSE_OUT |
                 MouseEvent.MOUSE_DOWN | MouseEvent.MOUSE_UP | MouseEvent.CLICK | MouseEvent.DBL_CLICK |
-                MouseEvent.RIGHT_MOUSE_DOWN | MouseEvent.RIGHT_MOUSE_UP:
+                MouseEvent.RIGHT_MOUSE_DOWN | MouseEvent.RIGHT_MOUSE_UP | MouseEvent.MIDDLE_MOUSE_DOWN |
+                MouseEvent.MIDDLE_MOUSE_UP:
                 if (_eventMap.exists(type) == false) {
                     _eventMap.set(type, listener);
                     if (type == MouseEvent.CLICK) {

--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -619,13 +619,13 @@ class ComponentImpl extends ComponentBase {
             if (event.type == "pointerdown") { // handle right button mouse events better
                 switch (which) {
                     case 1: type = MouseEvent.MOUSE_DOWN;
-                    case 2: type = MouseEvent.MOUSE_DOWN; // should be mouse middle, but there is no haxe equiv (yet);
+                    case 2: type = MouseEvent.MIDDLE_MOUSE_DOWN;
                     case 3: type = MouseEvent.RIGHT_MOUSE_DOWN;
                 }
             } else if (event.type == "pointerup") { // handle right button mouse events better
                 switch (which) {
                     case 1: type = MouseEvent.MOUSE_UP;
-                    case 2: type = MouseEvent.MOUSE_UP; // should be mouse middle, but there is no haxe equiv (yet);
+                    case 2: type = MouseEvent.MIDDLE_MOUSE_UP;
                     case 3: type = MouseEvent.RIGHT_MOUSE_UP;
                 }
             }

--- a/haxe/ui/backend/ScreenImpl.hx
+++ b/haxe/ui/backend/ScreenImpl.hx
@@ -342,7 +342,8 @@ class ScreenImpl extends ScreenBase {
         switch (type) {
             case MouseEvent.MOUSE_MOVE | MouseEvent.MOUSE_OVER | MouseEvent.MOUSE_OUT |
                 MouseEvent.MOUSE_DOWN | MouseEvent.MOUSE_UP | MouseEvent.CLICK | MouseEvent.DBL_CLICK |
-                MouseEvent.RIGHT_MOUSE_DOWN | MouseEvent.RIGHT_MOUSE_UP | MouseEvent.RIGHT_CLICK:
+                MouseEvent.RIGHT_MOUSE_DOWN | MouseEvent.RIGHT_MOUSE_UP | MouseEvent.RIGHT_CLICK |
+                MouseEvent.MIDDLE_MOUSE_DOWN | MouseEvent.MIDDLE_MOUSE_UP:
 
                 if (_mapping.exists(type) == false) {
                     _mapping.set(type, listener);
@@ -371,7 +372,8 @@ class ScreenImpl extends ScreenBase {
         switch (type) {
             case MouseEvent.MOUSE_MOVE | MouseEvent.MOUSE_OVER | MouseEvent.MOUSE_OUT |
                 MouseEvent.MOUSE_DOWN | MouseEvent.MOUSE_UP | MouseEvent.CLICK | MouseEvent.DBL_CLICK |
-                MouseEvent.RIGHT_MOUSE_DOWN | MouseEvent.RIGHT_MOUSE_UP | MouseEvent.RIGHT_CLICK:
+                MouseEvent.RIGHT_MOUSE_DOWN | MouseEvent.RIGHT_MOUSE_UP | MouseEvent.RIGHT_CLICK |
+                MouseEvent.MIDDLE_MOUSE_DOWN | MouseEvent.MIDDLE_MOUSE_UP:
                 _mapping.remove(type);
                 container.removeEventListener(EventMapper.HAXEUI_TO_DOM.get(type), __onMouseEvent);
                 if (type == MouseEvent.RIGHT_MOUSE_DOWN || type == MouseEvent.RIGHT_MOUSE_UP) {
@@ -426,13 +428,13 @@ class ScreenImpl extends ScreenBase {
         if (event.type == "pointerdown") { // handle right button mouse events better
             switch (which) {
                 case 1: type = MouseEvent.MOUSE_DOWN;
-                case 2: type = MouseEvent.MOUSE_DOWN; // should be mouse middle, but there is no haxe equiv (yet);
+                case 2: type = MouseEvent.MIDDLE_MOUSE_DOWN; // should be mouse middle, but there is no haxe equiv (yet);
                 case 3: type = MouseEvent.RIGHT_MOUSE_DOWN;
             }
         } else if (event.type == "pointerup") { // handle right button mouse events better
             switch (which) {
                 case 1: type = MouseEvent.MOUSE_UP;
-                case 2: type = MouseEvent.MOUSE_UP; // should be mouse middle, but there is no haxe equiv (yet);
+                case 2: type = MouseEvent.MIDDLE_MOUSE_UP; // should be mouse middle, but there is no haxe equiv (yet);
                 case 3: type = MouseEvent.RIGHT_MOUSE_UP;
             }
         }

--- a/haxe/ui/backend/html5/EventMapper.hx
+++ b/haxe/ui/backend/html5/EventMapper.hx
@@ -12,6 +12,8 @@ class EventMapper {
         haxe.ui.events.MouseEvent.RIGHT_MOUSE_DOWN => "pointerdown",
         haxe.ui.events.MouseEvent.RIGHT_MOUSE_UP => "pointerup",
         haxe.ui.events.MouseEvent.RIGHT_CLICK => "contextmenu",
+        haxe.ui.events.MouseEvent.MIDDLE_MOUSE_DOWN => "pointerdown",
+        haxe.ui.events.MouseEvent.MIDDLE_MOUSE_UP => "pointerup",
         haxe.ui.events.UIEvent.CHANGE => "change",
         haxe.ui.events.KeyboardEvent.KEY_DOWN => "keydown",
         haxe.ui.events.KeyboardEvent.KEY_UP => "keyup",


### PR DESCRIPTION
This updates the mouse events so that it now triggers the corresponding `MIDDLE_MOUSE` event. With the old behavior the middle mouse button would trigger the `MOUSE_DOWN` and `MOUSE_UP` events.